### PR TITLE
feat: add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        # Note: image includes ffmpeg + intel-media-va-driver (ubuntu:24.04 base).
+        # Build takes ~5-8 min on first run; driver installs fine without /dev/dri device.
+        run: docker build -t video-pipeline-x86 .
+
+      - name: Start container
+        run: |
+          docker run -d \
+            --name video-pipeline \
+            -p 8002:8002 \
+            video-pipeline-x86
+
+      - name: Wait for service to be healthy
+        run: |
+          echo "Waiting for video pipeline service..."
+          timeout 90 bash -c \
+            'until curl -sf http://localhost:8002/api/v1/video-pipeline/health/; do sleep 3; done'
+
+      - name: Assert health endpoint returns 200
+        run: |
+          curl -sf http://localhost:8002/api/v1/video-pipeline/health/ | grep '"status"'
+
+      - name: Assert root endpoint is reachable
+        run: |
+          curl -sf http://localhost:8002/ | grep "running"
+
+      - name: Print container logs on failure
+        if: failure()
+        run: docker logs video-pipeline


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` — first CI for this repo
- On every push/PR to `main`: builds the Docker image, starts the container, asserts the health endpoint returns 200

## What the workflow does

1. `docker build` — full ubuntu:24.04 image with ffmpeg + intel-media-va-driver (no GPU required in CI)
2. `docker run` — starts service on port 8002
3. `GET /api/v1/video-pipeline/health/` — waits up to 90s (ubuntu base is slower to cold-start), then asserts `"status"` field present
4. `GET /` — asserts root endpoint responds

## Notes

- The intel-media-va-driver is installed but unused in CI (no `/dev/dri` device) — this is expected and harmless
- 90s timeout accounts for the heavier ubuntu:24.04 + ffmpeg base image startup time

## Why

Catches broken Docker builds and startup crashes before they reach `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)